### PR TITLE
加入日期除錯訊息後檢查並修正 Solar 物件初始化問題

### DIFF
--- a/LunarSolarConverter.js
+++ b/LunarSolarConverter.js
@@ -8,10 +8,10 @@ function Lunar() {
     this.lunarYear = 0;
 }
 
-function Solar() {
-    this.solarDay = 0;
-    this.solarMonth = 0;
-    this.solarYear = 0;
+function Solar(year, month, day) {
+    this.solarYear = year;
+    this.solarMonth = month;
+    this.solarDay = day;
 }
 
 function LunarSolarConverter() {

--- a/index.html
+++ b/index.html
@@ -125,7 +125,8 @@
     // 當網頁載入完成後，自動帶入預設值
     document.addEventListener("DOMContentLoaded", function() {
       const today = new Date();
-      
+      console.log("今天的日期物件：", today);
+      console.log("today.getDate() 的結果：", today.getDate());
       // 使用 Lunar-Solar-Calendar-Converter 轉換公曆到農曆
       // 此函式庫提供兩個物件：Solar 和 LunarSolarConverter
       var solar = new Solar(today.getFullYear(), today.getMonth() + 1, today.getDate());

--- a/index.html
+++ b/index.html
@@ -125,15 +125,13 @@
     // 當網頁載入完成後，自動帶入預設值
     document.addEventListener("DOMContentLoaded", function() {
       const today = new Date();
-      console.log("今天的日期物件：", today);
-      console.log("today.getDate() 的結果：", today.getDate());
+
       // 使用 Lunar-Solar-Calendar-Converter 轉換公曆到農曆
       // 此函式庫提供兩個物件：Solar 和 LunarSolarConverter
       var solar = new Solar(today.getFullYear(), today.getMonth() + 1, today.getDate());
       var converter = new LunarSolarConverter();
       var lunar = converter.SolarToLunar(solar);
-      console.log("solar  object:", solar);
-      console.log("lunar object:", lunar);
+
       // 設定預設值，注意這邊依據函式庫返回的物件屬性名稱
       document.getElementById("lunarMonth").value = lunar.lunarMonth;
       document.getElementById("lunarDay").value = lunar.lunarDay;

--- a/index.html
+++ b/index.html
@@ -132,6 +132,8 @@
       var solar = new Solar(today.getFullYear(), today.getMonth() + 1, today.getDate());
       var converter = new LunarSolarConverter();
       var lunar = converter.SolarToLunar(solar);
+      console.log("solar  object:", solar);
+      console.log("lunar object:", lunar);
       // 設定預設值，注意這邊依據函式庫返回的物件屬性名稱
       document.getElementById("lunarMonth").value = lunar.lunarMonth;
       document.getElementById("lunarDay").value = lunar.lunarDay;


### PR DESCRIPTION
## 變更內容
- 新增 console.log 除錯訊息，追蹤 today 物件及其各個日期屬性，確認系統日期取得正確。
- 確認經修正後，網頁能正確自動填入公曆日期和轉換後的農曆日期。
- 修改 Solar 建構子，讓它能接收並初始化年、月、日參數，解決因未正確初始化而導致 LunarSolarConverter 轉換錯誤的問題。

## 測試情況
- 於開發者工具中確認 `today.getDate()`、`today.getMonth()`、`today.getFullYear()` 輸出正確。
- 經 LunarSolarConverter 轉換後，Solar 與 Lunar 物件皆正確顯示日期數值。
- 網頁上自動填入的日期欄位皆正確反映目前的日期資訊。

## 備註
這次修正主要針對 Solar 物件未接受參數初始化的 Bug，導致後續農曆轉換出現錯誤。請確認無誤後合併至 main 分支。
